### PR TITLE
Arbitrary header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ server.register([
 ], function(err) {
   /* etc. */
 });
+
+// You can also specify any arbitrary header to set as the request ID
+server.register({
+  register: RequestID,
+  options: { header: 'x-my-custom-id-header' }
+}, function(err) {
+  /* etc. */
+});
+
 ```
 
 [heroku-http-request-id]: https://devcenter.heroku.com/articles/http-request-id

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
 module.exports.register = function(server, _options, next) {
+  var header = (_options && _options.header) || 'x-request-id';
   server.ext('onRequest', function(request, reply) {
-    request.id = request.headers['x-request-id'] || request.id;
+    request.id = request.headers[header] || request.id;
     return reply.continue();
   });
 


### PR DESCRIPTION
Default usage retains the current implementation. Adds support for supplying a different header to set as the request ID.
